### PR TITLE
feat: add 15 prompts and 15 guides (FR/EN)

### DIFF
--- a/guides.en.json
+++ b/guides.en.json
@@ -66,7 +66,7 @@
     "date": "2025-02-08"
   },
   {
-    "id": "pricing-strategy-builder",
+    "id": "pricing_strategy_builder",
     "title": "Building a Product Pricing Strategy",
     "description": "The guide to designing a SaaS/product pricing grid that maximizes revenue and conversion.",
     "category": "business",
@@ -77,7 +77,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "competitor-radar",
+    "id": "competitor_radar",
     "title": "Mapping Your Competitors Methodically",
     "description": "How to analyze competition without spending weeks on it, and turn it into strategic decisions.",
     "category": "business",
@@ -88,7 +88,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "business-model-stress-test",
+    "id": "business_model_stress_test",
     "title": "Stress-Testing Your Business Model",
     "description": "How to crash-test your economic model before the market does it for you.",
     "category": "business",
@@ -99,7 +99,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "customer-persona-sculptor",
+    "id": "customer_persona_sculptor",
     "title": "Creating Customer Personas That Actually Work",
     "description": "The guide to building personas based on facts and behaviors, not marketing cliches.",
     "category": "business",
@@ -110,7 +110,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "pitch-deck-architect",
+    "id": "pitch_deck_architect",
     "title": "Structuring a Compelling Pitch Deck",
     "description": "The slide-by-slide guide to building a pitch deck that tells a story and makes investors want in.",
     "category": "business",
@@ -121,7 +121,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "landing-page-copywriter",
+    "id": "landing_page_copywriter",
     "title": "Writing a Landing Page That Converts",
     "description": "The guide to writing landing page copy section by section, using conversion principles that work.",
     "category": "marketing",
@@ -132,7 +132,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "cold-outreach-crafter",
+    "id": "cold_outreach_crafter",
     "title": "Cold Outreach: Getting Replies",
     "description": "The field guide to writing prospecting messages that don't end up in the trash.",
     "category": "growth",
@@ -143,7 +143,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "linkedin-post-generator",
+    "id": "linkedin_post_generator",
     "title": "Publishing on LinkedIn in 5 Minutes",
     "description": "The express guide to turning an idea into a publishable LinkedIn post without spending an hour.",
     "category": "marketing",
@@ -154,7 +154,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "seo-content-brief-builder",
+    "id": "seo_content_brief_builder",
     "title": "Creating SEO Briefs That Rank",
     "description": "The guide to structuring complete and actionable SEO content briefs for your writers or yourself.",
     "category": "marketing",
@@ -165,7 +165,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "email-onboarding-sequence",
+    "id": "email_onboarding_sequence",
     "title": "Designing an Email Onboarding Sequence",
     "description": "The guide to creating onboarding emails that activate users and reduce churn.",
     "category": "marketing",
@@ -176,7 +176,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "sop-generator",
+    "id": "sop_generator",
     "title": "Documenting Your Processes with SOPs",
     "description": "The guide to turning informal processes into clear, delegatable, and improvable procedures.",
     "category": "automation",
@@ -187,7 +187,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "meeting-to-actions",
+    "id": "meeting_to_actions",
     "title": "Turning Meetings into Concrete Actions",
     "description": "The guide to never leaving a meeting wondering who does what.",
     "category": "productivity",
@@ -198,7 +198,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "delegation-framework",
+    "id": "delegation_framework",
     "title": "Learning to Delegate Effectively",
     "description": "The guide to stop doing everything yourself and build a delegation system that works.",
     "category": "productivity",
@@ -209,7 +209,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "prd-writer",
+    "id": "prd_writer",
     "title": "Writing a Clear and Actionable PRD",
     "description": "The guide to writing Product Requirements Documents that eliminate ambiguity between product and engineering.",
     "category": "dev",
@@ -220,7 +220,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "unit-economics-calculator",
+    "id": "unit_economics_calculator",
     "title": "Understanding and Calculating Unit Economics",
     "description": "The guide to mastering the metrics that determine if your business is viable or doomed.",
     "category": "business",

--- a/guides.fr.json
+++ b/guides.fr.json
@@ -66,7 +66,7 @@
     "date": "2025-02-08"
   },
   {
-    "id": "pricing-strategy-builder",
+    "id": "pricing_strategy_builder",
     "title": "Construire une strategie de pricing produit",
     "description": "Le guide pour concevoir une grille tarifaire SaaS/produit qui maximise revenus et conversion.",
     "category": "business",
@@ -77,7 +77,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "competitor-radar",
+    "id": "competitor_radar",
     "title": "Cartographier ses concurrents methodiquement",
     "description": "Comment analyser la concurrence sans y passer des semaines, et en tirer des decisions strategiques.",
     "category": "business",
@@ -88,7 +88,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "business-model-stress-test",
+    "id": "business_model_stress_test",
     "title": "Stress-tester son business model",
     "description": "Comment soumettre ton modele economique a un crash test avant que le marche le fasse pour toi.",
     "category": "business",
@@ -99,7 +99,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "customer-persona-sculptor",
+    "id": "customer_persona_sculptor",
     "title": "Creer des personas clients qui servent vraiment",
     "description": "Le guide pour construire des personas basees sur des faits et des comportements, pas des cliches marketing.",
     "category": "business",
@@ -110,7 +110,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "pitch-deck-architect",
+    "id": "pitch_deck_architect",
     "title": "Structurer un pitch deck convaincant",
     "description": "Le guide slide par slide pour construire un pitch deck qui raconte une histoire et donne envie d'investir.",
     "category": "business",
@@ -121,7 +121,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "landing-page-copywriter",
+    "id": "landing_page_copywriter",
     "title": "Ecrire une landing page qui convertit",
     "description": "Le guide pour rediger le copy d'une landing page section par section, avec les principes de conversion qui marchent.",
     "category": "marketing",
@@ -132,7 +132,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "cold-outreach-crafter",
+    "id": "cold_outreach_crafter",
     "title": "Prospection a froid : obtenir des reponses",
     "description": "Le guide terrain pour ecrire des messages de prospection qui ne finissent pas a la corbeille.",
     "category": "growth",
@@ -143,7 +143,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "linkedin-post-generator",
+    "id": "linkedin_post_generator",
     "title": "Publier sur LinkedIn en 5 minutes",
     "description": "Le guide express pour transformer une idee en post LinkedIn publiable sans y passer une heure.",
     "category": "marketing",
@@ -154,7 +154,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "seo-content-brief-builder",
+    "id": "seo_content_brief_builder",
     "title": "Creer des briefs SEO qui rankent",
     "description": "Le guide pour structurer des briefs de contenu SEO complets et actionnables pour tes redacteurs ou pour toi-meme.",
     "category": "marketing",
@@ -165,7 +165,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "email-onboarding-sequence",
+    "id": "email_onboarding_sequence",
     "title": "Concevoir une sequence d'onboarding email",
     "description": "Le guide pour creer des emails d'onboarding qui activent tes utilisateurs et reduisent le churn.",
     "category": "marketing",
@@ -176,7 +176,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "sop-generator",
+    "id": "sop_generator",
     "title": "Documenter ses process avec des SOP",
     "description": "Le guide pour transformer tes process informels en procedures claires, delegables et ameliorables.",
     "category": "automation",
@@ -187,7 +187,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "meeting-to-actions",
+    "id": "meeting_to_actions",
     "title": "Transformer ses reunions en actions concretes",
     "description": "Le guide pour ne plus sortir de reunion en se demandant qui fait quoi.",
     "category": "productivity",
@@ -198,7 +198,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "delegation-framework",
+    "id": "delegation_framework",
     "title": "Apprendre a deleguer efficacement",
     "description": "Le guide pour arreter de tout faire soi-meme et construire un systeme de delegation qui fonctionne.",
     "category": "productivity",
@@ -209,7 +209,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "prd-writer",
+    "id": "prd_writer",
     "title": "Rediger un PRD clair et actionnable",
     "description": "Le guide pour ecrire des Product Requirements Documents qui eliminent l'ambiguite entre product et dev.",
     "category": "dev",
@@ -220,7 +220,7 @@
     "date": "2026-02-16"
   },
   {
-    "id": "unit-economics-calculator",
+    "id": "unit_economics_calculator",
     "title": "Comprendre et calculer ses unit economics",
     "description": "Le guide pour maitriser les metriques qui determinent si ton business est viable ou condamne.",
     "category": "business",


### PR DESCRIPTION
## Summary
- Add 15 new structured prompts (FR/EN): pricing strategy, competitor radar, business model stress test, customer persona, pitch deck, landing page copy, cold outreach, LinkedIn post, SEO brief, email onboarding, SOP generator, meeting-to-actions, delegation framework, PRD writer, unit economics
- Add 15 matching guides (FR/EN) with full markdown content for each prompt
- Fix guide IDs to use underscores (matching prompt IDs) for front-end consistency

## Test plan
- [x] Verify JSON validity with `jq empty` on all files
- [x] Confirm FR/EN ID sync passes CI
- [x] Check that prompt/guide IDs match on the front-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)