### PR TITLE
Ajout de AI Router aux outils d'infrastructure

### DIFF
--- a/tools.en.json
+++ b/tools.en.json
@@ -180,5 +180,13 @@
     "link": "https://docs.anthropic.com/en/docs/claude-code",
     "description": "AI assistant integrated into code and refactoring workflows.",
     "why": "Move faster without sacrificing readability or logic."
+  },
+  {
+    "id": "ai_router",
+    "name": "AI Router",
+    "category": "infra_pragmatique",
+    "link": "https://ai-router.dev",
+    "description": "OpenAI-compatible API relay for using ChatGPT / GPT in applications and development tools.",
+    "why": "Keep an OpenAI-compatible client format in a script or development tool while monitoring usage."
   }
 ]

--- a/tools.fr.json
+++ b/tools.fr.json
@@ -180,5 +180,13 @@
     "link": "https://docs.anthropic.com/en/docs/claude-code",
     "description": "Assistant IA intégré au code et au refactoring.",
     "why": "Aller plus vite sans sacrifier la lisibilité ni la logique."
+  },
+  {
+    "id": "ai_router",
+    "name": "AI Router",
+    "category": "infra_pragmatique",
+    "link": "https://ai-router.dev/fr/",
+    "description": "Passerelle API compatible OpenAI pour utiliser ChatGPT / GPT dans des applications et des outils de développement.",
+    "why": "Conserver un format de client compatible OpenAI dans un script ou un outil de dev tout en suivant l'utilisation."
   }
 ]


### PR DESCRIPTION
## Type
Nouvel outil

## Outil
- **Nom :** AI Router
- **Catégorie :** `infra_pragmatique`
- **Fichiers :** `tools.fr.json`, `tools.en.json`

## Pourquoi cette proposition
AI Router est une passerelle API compatible OpenAI pour les applications et outils de développement utilisant ChatGPT / GPT. Les deux fichiers conservent le même ID et le même ordre, avec le lien français `https://ai-router.dev/fr/` dans la version française et le lien racine dans la version anglaise.

## Vérifications
- JSON valide
- IDs et ordre identiques entre les listes française et anglaise
- Liens vérifiés (HTTP 200)

## Transparence
Soumis au nom de AI Router. Aucun lien affilié, placement rémunéré ou contenu sponsorisé.